### PR TITLE
Fix web socket type error.

### DIFF
--- a/src/client/LoggedIn/index.js
+++ b/src/client/LoggedIn/index.js
@@ -45,7 +45,10 @@ const LoggedIn = ({ username }) => {
     };
 
     setInterval(() => {
-      socket.send(JSON.stringify({}));
+      // Heartbeat while connection is open.
+      if (socket.ws.readyState == WebSocket.OPEN) {
+        socket.ws.send(JSON.stringify({}));
+      }
     }, FIVE_SECONDS_IN_MS);
   }, []);
 


### PR DESCRIPTION
The client sends an empty string to the server as a heartbeat.  That interval is initiated at the creation of the websocket on the client side. It is unaware of status of the connection on the server side.

This leads to trying to send messages on a socket that may not have a send available.
Fix this by checking that the websocket is connected before sending.

Possible fix for #26.