### PR TITLE
Remove card that user plays from hand.

### DIFF
--- a/src/actions/game.js
+++ b/src/actions/game.js
@@ -26,10 +26,11 @@ export function buyCard({ cardName, id, location, logIds, username }) {
   };
 }
 
-export function playTreasure({ cardName, id, logIds, username }) {
+export function playTreasure({ cardName, cardIndex, id, logIds, username }) {
   return {
     type: "PLAY_TREASURE",
     cardName,
+    cardIndex,
     id,
     logIds,
     username
@@ -40,10 +41,11 @@ export function gainActions({ actionAmount, id }) {
   return { type: "GAIN_ACTIONS", actionAmount, id };
 }
 
-export function playAction({ cardName, id, logIds, username }) {
+export function playAction({ cardName, cardIndex, id, logIds, username }) {
   return {
     type: "PLAY_ACTION",
     cardName,
+    cardIndex,
     id,
     logIds,
     username

--- a/src/client/Game/Hand/index.js
+++ b/src/client/Game/Hand/index.js
@@ -14,21 +14,21 @@ const Hand = ({ hand, playerId, playerRequest, socket }) => {
     setSelectedCards([]);
   }
 
-  function handleCardClick(name, index) {
+  function handleCardClick(cardName, cardIndex) {
     let selectedCardsCopy = [...selectedCards];
     if (
       playerRequest &&
       playerRequest.id === playerId &&
       playerRequest.type === "SELECT_CARDS_IN_HAND"
     ) {
-      if (selectedCardsCopy.includes(index)) {
-        let selectedIndex = selectedCardsCopy.indexOf(index);
+      if (selectedCardsCopy.includes(cardIndex)) {
+        let selectedIndex = selectedCardsCopy.indexOf(cardIndex);
         selectedCardsCopy = [
           ...selectedCardsCopy.slice(0, selectedIndex),
           ...selectedCardsCopy.slice(selectedIndex + 1)
         ];
       } else {
-        selectedCardsCopy.push(index);
+        selectedCardsCopy.push(cardIndex);
         if (
           playerRequest.maxSelectAmount != null &&
           selectedCardsCopy.length > playerRequest.maxSelectAmount
@@ -38,7 +38,9 @@ const Hand = ({ hand, playerId, playerRequest, socket }) => {
       }
       setSelectedCards(selectedCardsCopy);
     } else {
-      socket.send(JSON.stringify({ type: "ASYNC_PLAY_CARD", name }));
+      socket.send(
+        JSON.stringify({ type: "ASYNC_PLAY_CARD", cardName, cardIndex })
+      );
     }
   }
 

--- a/src/reducers/game/players.js
+++ b/src/reducers/game/players.js
@@ -58,7 +58,13 @@ const players = (state = [], action) => {
     case "PLAY_TREASURE":
       playerIndex = state.findIndex(player => player.id === action.id);
       player = state[playerIndex];
+
+      // Lookup the cardIndex in the hand by card name,
+      // but if an index is specified use that instead.
       cardIndex = player.cards.hand.findIndex(c => c === action.cardName);
+      if (action.cardIndex) {
+        cardIndex = action.cardIndex;
+      }
 
       return [
         ...state.slice(0, playerIndex),

--- a/src/sagas/cards/base/copper.js
+++ b/src/sagas/cards/base/copper.js
@@ -2,7 +2,7 @@ import { put, takeEvery, select } from "redux-saga/effects";
 import { playTreasure } from "../../../actions";
 import { gamePlayerIdsSelector, gamePlayerSelector } from "../../../selectors";
 
-export function* asyncPlayCopper() {
+export function* asyncPlayCopper({ cardIndex }) {
   const player = yield select(gamePlayerSelector);
   const playerIds = yield select(gamePlayerIdsSelector);
 
@@ -10,6 +10,7 @@ export function* asyncPlayCopper() {
     playTreasure({
       cardName: "Copper",
       id: player.id,
+      cardIndex: cardIndex,
       logIds: playerIds,
       username: player.username
     })

--- a/src/sagas/cards/base/gold.js
+++ b/src/sagas/cards/base/gold.js
@@ -2,13 +2,14 @@ import { put, takeEvery, select } from "redux-saga/effects";
 import { playTreasure } from "../../../actions";
 import { gamePlayerIdsSelector, gamePlayerSelector } from "../../../selectors";
 
-export function* asyncPlayGold() {
+export function* asyncPlayGold({ cardIndex }) {
   const player = yield select(gamePlayerSelector);
   const playerIds = yield select(gamePlayerIdsSelector);
 
   yield put(
     playTreasure({
       cardName: "Gold",
+      cardIndex: cardIndex,
       id: player.id,
       logIds: playerIds,
       username: player.username

--- a/src/sagas/cards/base/silver.js
+++ b/src/sagas/cards/base/silver.js
@@ -2,7 +2,7 @@ import { put, takeEvery, select } from "redux-saga/effects";
 import { gainFloatingGold, playTreasure } from "../../../actions";
 import { gamePlayerIdsSelector, gamePlayerSelector } from "../../../selectors";
 
-export function* asyncPlaySilver() {
+export function* asyncPlaySilver({ cardIndex }) {
   const player = yield select(gamePlayerSelector);
   const playerIds = yield select(gamePlayerIdsSelector);
 
@@ -16,6 +16,7 @@ export function* asyncPlaySilver() {
   yield put(
     playTreasure({
       cardName: "Silver",
+      cardIndex: cardIndex,
       id: player.id,
       logIds: playerIds,
       username: player.username

--- a/src/sagas/game.js
+++ b/src/sagas/game.js
@@ -145,7 +145,7 @@ export function* asyncEndTurn({ id }) {
   );
 }
 
-export function* asyncPlayCard({ id, name: cardName }) {
+export function* asyncPlayCard({ id, cardName, cardIndex }) {
   const currentPlayer = yield select(currentPlayerSelector);
   const player = yield select(gamePlayerSelector);
   const playerRequest = yield select(gamePlayerRequestSelector);
@@ -166,7 +166,10 @@ export function* asyncPlayCard({ id, name: cardName }) {
     return;
   }
 
-  yield put({ type: `ASYNC_PLAY_${snakeCase(cardName).toUpperCase()}` });
+  yield put({
+    type: `ASYNC_PLAY_${snakeCase(cardName).toUpperCase()}`,
+    cardIndex
+  });
 }
 
 export function* asyncPlayAllTreasures({ id }) {
@@ -182,6 +185,7 @@ export function* asyncPlayAllTreasures({ id }) {
     .length;
   const copperCount = player.cards.hand.filter(card => card === "Copper")
     .length;
+  // Don't need card indexes here since all available treasures will be played.
   for (let i = 0; i < goldCount; i++) {
     yield put({ type: "ASYNC_PLAY_GOLD" });
   }


### PR DESCRIPTION
Remove card that user plays from hand.

Previously, when a user selected a card to play the client would send
the card name and the server would search for the card in that players
hand. And then play and remove it from their hand.

This works great, except when there are multiple cards with the same
name in the user's hand. If this is the case the server may select a
card of the same name, but located in a different position in the
hand. While the effect will be the same, i.e. the cards are fungible
These cards as different look different to the user.
It's disorienting from their perspective if the card selected was not
played, but a different card was.

This was most apparent when playing treasures since they are more
likely to have duplicates in a single hand.  In these cases, users
would complain that the game "reorders their hands".  No Bueno!

To fix this pass the index of the card played to the server.
Then use that index when removing the card from the array of
cards that represent the user's hand.

Cards in a player's hands are represented as an array so passing the
index of the card is enough to uniquely identify the card.  We might
be able to get away with just passing the index, but who cares!