### PR TITLE
issue/36/fix id prop types error

### DIFF
--- a/src/client/Game/Log/index.js
+++ b/src/client/Game/Log/index.js
@@ -81,7 +81,7 @@ Log.propTypes = {
   isSpectator: PropTypes.bool.isRequired,
   log: PropTypes.arrayOf(
     PropTypes.shape({
-      ids: PropTypes.string,
+      ids: PropTypes.arrayOf(PropTypes.string),
       text: PropTypes.string,
       type: PropTypes.string
     })

--- a/src/client/Game/Score/index.js
+++ b/src/client/Game/Score/index.js
@@ -53,7 +53,7 @@ const Score = ({ score, socket }) =>
   ) : null;
 
 Score.propTypes = {
-  score: PropTypes.object.isRequired,
+  score: PropTypes.object,
   socket: PropTypes.object
 };
 

--- a/src/client/Game/Score/index.js
+++ b/src/client/Game/Score/index.js
@@ -53,7 +53,7 @@ const Score = ({ score, socket }) =>
   ) : null;
 
 Score.propTypes = {
-  score: PropTypes.object,
+  score: PropTypes.arrayOf(PropTypes.object),
   socket: PropTypes.object
 };
 

--- a/src/client/Game/index.js
+++ b/src/client/Game/index.js
@@ -81,7 +81,7 @@ Game.propTypes = {
       })
     ),
     playerRequest: PropTypes.object,
-    score: PropTypes.object
+    score: PropTypes.arrayOf(PropTypes.object)
   }).isRequired,
   logEndRef: PropTypes.object.isRequired,
   playerId: PropTypes.string.isRequired,

--- a/src/client/Game/index.js
+++ b/src/client/Game/index.js
@@ -75,7 +75,7 @@ Game.propTypes = {
     }),
     log: PropTypes.arrayOf(
       PropTypes.shape({
-        ids: PropTypes.string,
+        ids: PropTypes.arrayOf(PropTypes.string),
         text: PropTypes.string,
         type: PropTypes.string
       })


### PR DESCRIPTION
A bunch of type errors in the console.

- Resolve proptypes error for log messages
- Allow score to be null. At the start of the game the score is initialized to null, but the score variable is marked as required in the prop types. It looks like the score component also expects score to be null. In fact the "game end" logic says that it will only show the score (which is also the game over dialog) if it is present.
- Update PropTypes for score.

Some other suggestions:
Add a game over state
Add a debugger
Add testing
